### PR TITLE
Fix/api

### DIFF
--- a/api/dapp.go
+++ b/api/dapp.go
@@ -59,7 +59,8 @@ func (a *DAppApi) SendEthereumTransaction(value, to, data string) (string, error
 
 	ethTx := resp.Msg.SendEthereumTransaction
 	if ethTx == nil {
-		resp.Closer <- errors.New("got nil response")
+		resp.Closer <- errors.New("got nil ethTx response")
+		return "", errors.New("got nil ethTx response")
 	}
 
 	objTx := map[string]interface{}{

--- a/api/dapp.go
+++ b/api/dapp.go
@@ -83,6 +83,8 @@ func (a *DAppApi) SendEthereumTransaction(value, to, data string) (string, error
 		return "", err
 	}
 
+	// Since closer is not passed further, we need to close it here to prevent timeout.
+	resp.Closer <- nil
 	return string(raw), nil
 
 }

--- a/mobile_interface.go
+++ b/mobile_interface.go
@@ -193,8 +193,13 @@ func SendResponse(id string, data string, responseError string, timeout int) err
 		return errors.New("you have to start panthalassa")
 	}
 
+	dataBytes, decodingError := base64.StdEncoding.DecodeString(data)
+	if decodingError != nil {
+		return decodingError
+	}
+
 	resp := &apiPB.Response{}
-	if err := proto.Unmarshal([]byte(data), resp); err != nil {
+	if err := proto.Unmarshal(dataBytes, resp); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixed several bugs in api:
 - SendEthereumTransaction request was not closed correctly, caused it's always being closed by timeout.
 - Panic caused by SendEthereumTransaction request cancellation (closing #75).
 - Invalid data passed to api using utf-8 encoded protobuf (closing #77).