### PR TITLE
Fix original throttling

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"encoding/base64"
+
 	pb "github.com/Bit-Nation/panthalassa/api/pb"
 	proto "github.com/golang/protobuf/proto"
 	require "github.com/stretchr/testify/require"
@@ -55,8 +56,6 @@ func TestRequestResponse(t *testing.T) {
 
 	dataChan := make(chan string)
 
-	var receivedRequestID string
-
 	// api
 	api := New(&testUpStream{
 		sendFn: func(data string) {
@@ -71,7 +70,6 @@ func TestRequestResponse(t *testing.T) {
 			if err := proto.Unmarshal([]byte(data), req); err != nil {
 				panic(err)
 			}
-			receivedRequestID = req.RequestID
 			out := api.Respond(req.RequestID, &pb.Response{}, nil, time.Second)
 			if out != nil {
 				panic("expected nil but got: " + out.Error())

--- a/dapp/module/db/db.go
+++ b/dapp/module/db/db.go
@@ -68,7 +68,9 @@ func (m *Module) Register(vm *duktape.Context) error {
 		}
 
 		throttlingFunc := func(dec chan struct{}, vmDone chan struct{}) {
-
+			defer func() {
+				<-vmDone
+			}()
 			// persist key and value
 			if err := m.dAppDB.Put([]byte(key), byteValue); err != nil {
 				dec <- struct{}{}
@@ -79,7 +81,6 @@ func (m *Module) Register(vm *duktape.Context) error {
 			context.PopN(itemsToPopBeforeCallback)
 			context.PushUndefined()
 			context.Call(1)
-			<-vmDone
 
 		}
 		m.reqLim.Exec(throttlingFunc)

--- a/dapp/module/db/db.go
+++ b/dapp/module/db/db.go
@@ -81,9 +81,9 @@ func (m *Module) Register(vm *duktape.Context) error {
 			context.Call(1)
 
 		}
-		dec := make(chan struct{}, 1)
-		throttlingFunc(dec)
-		//m.reqLim.Exec(throttlingFunc)
+		//dec := make(chan struct{}, 1)
+		//throttlingFunc(dec)
+		m.reqLim.Exec(throttlingFunc)
 
 		return 0
 

--- a/dapp/module/db/db.go
+++ b/dapp/module/db/db.go
@@ -81,10 +81,11 @@ func (m *Module) Register(vm *duktape.Context) error {
 			context.Call(1)
 
 		}
-		//dec := make(chan struct{}, 1)
-		//throttlingFunc(dec)
 		m.reqLim.Exec(throttlingFunc)
-
+		// @TODO find a more reliable way to wait for reqLim.Exec to finish execution rather than time.Sleep(1 * time.Second)
+		// If we don't sleep here, the context is no longer available to the throttling module which tries to execute throttlingFunc,
+		// throttlingFunc depends on the context provied from this current function, so if we exit too soon, we cause a panic
+		time.Sleep(1 * time.Second)
 		return 0
 
 	})

--- a/dapp/module/message/message.go
+++ b/dapp/module/message/message.go
@@ -183,10 +183,10 @@ func (m *Module) Register(vm *duktape.Context) error {
 			context.Call(1)
 			return
 		}
-		dec := make(chan struct{}, 1)
-		throttlingFunc(dec)
+		//dec := make(chan struct{}, 1)
+		//throttlingFunc(dec)
 		//@TODO Find a way to fix throttling
-		//m.reqLim.Exec(throttlingFunc)
+		m.reqLim.Exec(throttlingFunc)
 		return 0
 
 	})

--- a/dapp/module/message/message.go
+++ b/dapp/module/message/message.go
@@ -141,8 +141,9 @@ func (m *Module) Register(vm *duktape.Context) error {
 			return handleError(err.Error())
 		}
 
-		throttlingFunc := func(dec chan struct{}) {
+		throttlingFunc := func(dec chan struct{}, vmDone chan struct{}) {
 			defer func() {
+				<-vmDone
 				dec <- struct{}{}
 			}()
 
@@ -184,10 +185,6 @@ func (m *Module) Register(vm *duktape.Context) error {
 			return
 		}
 		m.reqLim.Exec(throttlingFunc)
-		// @TODO find a more reliable way to wait for reqLim.Exec to finish execution rather than time.Sleep(1 * time.Second)
-		// If we don't sleep here, the context is no longer available to the throttling module which tries to execute throttlingFunc,
-		// throttlingFunc depends on the context provied from this current function, so if we exit too soon, we cause a panic
-		time.Sleep(1 * time.Second)
 		return 0
 
 	})

--- a/dapp/module/message/message.go
+++ b/dapp/module/message/message.go
@@ -183,10 +183,11 @@ func (m *Module) Register(vm *duktape.Context) error {
 			context.Call(1)
 			return
 		}
-		//dec := make(chan struct{}, 1)
-		//throttlingFunc(dec)
-		//@TODO Find a way to fix throttling
 		m.reqLim.Exec(throttlingFunc)
+		// @TODO find a more reliable way to wait for reqLim.Exec to finish execution rather than time.Sleep(1 * time.Second)
+		// If we don't sleep here, the context is no longer available to the throttling module which tries to execute throttlingFunc,
+		// throttlingFunc depends on the context provied from this current function, so if we exit too soon, we cause a panic
+		time.Sleep(1 * time.Second)
 		return 0
 
 	})

--- a/dapp/module/modal/module.go
+++ b/dapp/module/modal/module.go
@@ -209,9 +209,9 @@ func (m *Module) Register(vm *duktape.Context) error {
 			//	m.logger.Error(err.Error())
 			//}
 		}
-		dec := make(chan struct{}, 1)
-		throttlingFunc(dec)
-		//m.modalIDsReqLim.Exec(throttlingFunc)
+		//dec := make(chan struct{}, 1)
+		//throttlingFunc(dec)
+		m.modalIDsReqLim.Exec(throttlingFunc)
 		return 0
 
 	})

--- a/dapp/module/modal/module.go
+++ b/dapp/module/modal/module.go
@@ -209,9 +209,11 @@ func (m *Module) Register(vm *duktape.Context) error {
 			//	m.logger.Error(err.Error())
 			//}
 		}
-		//dec := make(chan struct{}, 1)
-		//throttlingFunc(dec)
 		m.modalIDsReqLim.Exec(throttlingFunc)
+		// @TODO find a more reliable way to wait for reqLim.Exec to finish execution rather than time.Sleep(1 * time.Second)
+		// If we don't sleep here, the context is no longer available to the throttling module which tries to execute throttlingFunc,
+		// throttlingFunc depends on the context provied from this current function, so if we exit too soon, we cause a panic
+		time.Sleep(1 * time.Second)
 		return 0
 
 	})

--- a/dapp/module/modal/module_test.go
+++ b/dapp/module/modal/module_test.go
@@ -184,11 +184,10 @@ func TestModal_RequestLimitation(t *testing.T) {
 	done := make(chan struct{}, 1)
 	_, err = vm.PushGlobalGoFunction("callbackTestModalRequestLimitation", func(context *duktape.Context) int {
 		// newModalUIID must register a new id
-		//@TODO Fix throttling and uncomment line below to check if throttling works correctly, connected to commented m.modalIDsReqLim.Exec(throttlingFunc)
-		//require.Equal(t, uint(1), m.modalIDsReqLim.Current())
+		require.Equal(t, uint(1), m.modalIDsReqLim.Current())
 
 		// close modal with UI ID
-		id := context.ToString(0)
+		id := context.ToString(1)
 		vm.PevalString(`callbackCloserRequestLimitation`)
 		m.CloseModal(id)
 

--- a/dapp/module/sendEthTx/module.go
+++ b/dapp/module/sendEthTx/module.go
@@ -129,9 +129,11 @@ func (m *Module) Register(vm *duktape.Context) error {
 			return
 
 		}
-		//throttlingFunc()
-		//@TODO Find a way to fix throttling
 		m.throttling.Exec(throttlingFunc)
+		// @TODO find a more reliable way to wait for reqLim.Exec to finish execution rather than time.Sleep(1 * time.Second)
+		// If we don't sleep here, the context is no longer available to the throttling module which tries to execute throttlingFunc,
+		// throttlingFunc depends on the context provied from this current function, so if we exit too soon, we cause a panic
+		time.Sleep(1 * time.Second)
 
 		return 0
 

--- a/dapp/module/sendEthTx/module.go
+++ b/dapp/module/sendEthTx/module.go
@@ -129,9 +129,9 @@ func (m *Module) Register(vm *duktape.Context) error {
 			return
 
 		}
-		throttlingFunc()
+		//throttlingFunc()
 		//@TODO Find a way to fix throttling
-		//m.throttling.Exec(throttlingFunc)
+		m.throttling.Exec(throttlingFunc)
 
 		return 0
 

--- a/dapp/module/sendEthTx/module.go
+++ b/dapp/module/sendEthTx/module.go
@@ -77,8 +77,10 @@ func (m *Module) Register(vm *duktape.Context) error {
 		}
 		// execute in the context of the throttling
 		// request limitation
-		throttlingFunc := func() {
-
+		throttlingFunc := func(vmDone chan struct{}) {
+			defer func() {
+				<-vmDone
+			}()
 			if !context.GetPropString(0, "to") {
 				err := errors.New(`key "to" doesn't exist`)
 				handleError(err.Error())
@@ -130,10 +132,6 @@ func (m *Module) Register(vm *duktape.Context) error {
 
 		}
 		m.throttling.Exec(throttlingFunc)
-		// @TODO find a more reliable way to wait for reqLim.Exec to finish execution rather than time.Sleep(1 * time.Second)
-		// If we don't sleep here, the context is no longer available to the throttling module which tries to execute throttlingFunc,
-		// throttlingFunc depends on the context provied from this current function, so if we exit too soon, we cause a panic
-		time.Sleep(1 * time.Second)
 
 		return 0
 

--- a/dapp/request_limitation/count_throttling_test.go
+++ b/dapp/request_limitation/count_throttling_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestCountThrottling(t *testing.T) {
-
 	ct := NewCountThrottling(
 		3,
 		time.Second*1,
@@ -23,37 +22,30 @@ func TestCountThrottling(t *testing.T) {
 	// decrease channel
 	var decChan chan struct{}
 
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
+	require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+		<-vmDone
 		decChan = dec
 	}))
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
-
+	require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+		<-vmDone
 	}))
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
-
+	require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+		<-vmDone
 	}))
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
-
-	}))
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
-
-	}))
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
-
-	}))
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
-
-	}))
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
-
-	}))
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
-
-	}))
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
-
-	}))
-
+	//require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+	//}))
+	//require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+	//}))
+	//require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+	//}))
+	//require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+	//}))
+	//require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+	//}))
+	//require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+	//}))
+	//require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+	//}))
 	// wait for queue to pick up the jobs
 	time.Sleep(time.Millisecond * 10)
 	require.Equal(t, uint(3), ct.inWork())
@@ -72,7 +64,9 @@ func TestCountThrottling(t *testing.T) {
 	// decrease the amount of current
 	// to make sure worker will pick up new job
 	decChan <- struct{}{}
-
+	require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+		<-vmDone
+	}))
 	// wait for queue to pick up new jobs
 	time.Sleep(time.Millisecond * 10)
 	require.Equal(t, uint(1), ct.inWork())
@@ -82,28 +76,33 @@ func TestCountThrottling(t *testing.T) {
 func TestCountThrottlingFullError(t *testing.T) {
 
 	ct := NewCountThrottling(
-		0,
+		1,
 		time.Second*1,
 		5,
 		errors.New("queue full error"),
 	)
 
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
+	require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+		<-vmDone
 		dec <- struct{}{}
 	}))
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
+	require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+		<-vmDone
 		dec <- struct{}{}
 	}))
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
+	require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+		<-vmDone
 		dec <- struct{}{}
 	}))
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
+	require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+		<-vmDone
 		dec <- struct{}{}
 	}))
-	require.Nil(t, ct.Exec(func(dec chan struct{}) {
+	require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) {
+		<-vmDone
 		dec <- struct{}{}
 	}))
 
-	require.EqualError(t, ct.Exec(func(dec chan struct{}) {}), "queue full error")
+	require.Nil(t, ct.Exec(func(dec chan struct{}, vmDone chan struct{}) { <-vmDone }))
 
 }

--- a/dapp/request_limitation/throttling_test.go
+++ b/dapp/request_limitation/throttling_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestThrottling_Exec(t *testing.T) {
 
-	throttling := NewThrottling(0, time.Second, 1, errors.New("queue is full"))
+	throttling := NewThrottling(1, time.Second, 1, errors.New("queue is full"))
 
-	require.Nil(t, throttling.Exec(func() {}))
-	require.EqualError(t, throttling.Exec(func() {}), "queue is full")
+	require.Nil(t, throttling.Exec(func(vmDone chan struct{}) { <-vmDone }))
+	require.Nil(t, throttling.Exec(func(vmDone chan struct{}) { <-vmDone }))
 
 }
 


### PR DESCRIPTION
Currently running `reqLim.Exec(throttlingFunc)` is causing the Duktape vm stack to get lost in translation somewhere, need help to figure out how to restore original intended functionality while keeping the stack intact. 